### PR TITLE
Update gpad-gpi-2-0.md

### DIFF
--- a/specs/gpad-gpi-2-0.md
+++ b/specs/gpad-gpi-2-0.md
@@ -132,9 +132,9 @@ of specifying a URI that denotes the actual property used.
 
 ### Dates
 
-Dates are written into what is equivalent to the date portion of ISO-8601, omitting hyphens:
+Dates are written into what is equivalent to the date portion of ISO-8601, keeping hyphens:
 
-    YYYYMMDD ::= Year Month Day_of_month
+    YYYY-MM-DD ::= Year - Month - Day_of_month
     Year ::= digit digit digit digit
     Month ::= digit digit
     Day_of_month ::= digit digit


### PR DESCRIPTION
Removed "removing hyphens" from date requirements.  Added hyphens into line 137, please verify this is the right way to display:

>    YYYY-MM-DD ::= Year - Month - Day_of_month