### PR TITLE
WIP: blml specification of gpi format (experimental)

### DIFF
--- a/specs/gpi.yaml
+++ b/specs/gpi.yaml
@@ -3,7 +3,7 @@
 prefixes:
   biolink: 'https://w3id.org/biolink/vocab/'
   biolinkml: 'https://w3id.org/biolink/biolinkml/'
-  gff3: todo
+  gff3: 'https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md'
 
 classes:
   gene product:
@@ -18,30 +18,74 @@ classes:
       - xrefs
       - properties
 
+  gene product properties:
+    slots:
+      - todo
+
 slots:
   id:
     identifier: true
+    required: true
+    mappings:
+      - biolink:id
+      - alliancegenome:primaryId
+      - gff3:ID
     
   symbol:
-    type: symbol type
+    range: symbol type
     multivalued: false
+    required: true
+    mappings:
+      - alliancegenome:symbol
+      - rdfs:label
           
   name:
-    type: string
+    range: string
     multivalued: false
+    required: true
     mappings:
       - biolink:name
-      - gff3p:name
+      - gff3:Name
 
   synonyms:
-    type: string
+    range: string
     multivalued: true
     mappings:
       - biolink:synonym
-
+      - alliancegenome:synonyms
+      - gff3:Alias
+      - skos:altLabel
+      
   type:
-    type: category type
+    range: category type
     multivalued: false
+    required: true
+    mappings:
+      - biolink:type
+      - alliancegenome:soTermId
+      - gff3:type
+      - rdfs:type
+
+  taxon:
+    range: taxon type
+    multivalued: false
+    required: true
+    mappings:
+      - alliancegenome:taxonId
+      - RO:0002162
+      
+  parent:
+    range: gene product
+    multivalued: false  ##?
+    mappings:
+      - gff3:Parent
+
+  xrefs:
+    range: string
+    multivalued: true
+    mappings:
+      - alliancegenome:crossReferences  # inlined
+      - gff3:Dbxref
       
 types:
   symbol type:
@@ -53,4 +97,10 @@ types:
     typeof: uriorcurie
     description: >-
       A primitive type in which the value denotes a class within the biolink model.
-    
+
+  taxon type:
+    typeof: uriorcurie
+    pattern: "^NCBITaxon:\d+$"
+    description: >-
+      A primitive type in which the value denotes a class within the biolink model.
+      

--- a/specs/gpi.yaml
+++ b/specs/gpi.yaml
@@ -1,0 +1,56 @@
+## IN PROGRESS
+
+prefixes:
+  biolink: 'https://w3id.org/biolink/vocab/'
+  biolinkml: 'https://w3id.org/biolink/biolinkml/'
+  gff3: todo
+
+classes:
+  gene product:
+    slots:
+      - id
+      - symbol
+      - name
+      - synonyms
+      - type
+      - taxon
+      - parent
+      - xrefs
+      - properties
+
+slots:
+  id:
+    identifier: true
+    
+  symbol:
+    type: symbol type
+    multivalued: false
+          
+  name:
+    type: string
+    multivalued: false
+    mappings:
+      - biolink:name
+      - gff3p:name
+
+  synonyms:
+    type: string
+    multivalued: true
+    mappings:
+      - biolink:synonym
+
+  type:
+    type: category type
+    multivalued: false
+      
+types:
+  symbol type:
+    pattern: "^\S+$"
+    base: str
+    uri: xsd:string
+
+  category type:
+    typeof: uriorcurie
+    description: >-
+      A primitive type in which the value denotes a class within the biolink model.
+    


### PR DESCRIPTION
This is an experiment in providing a more computable schema and data dictionary for gpi (and later gpad) files. It does not replace the markdown docs, and is not intended for any practical use any time soon.

Some potential advantages downstream:

 - more computable unambiguous representation of datamodel
 - formal mappings to other data models and dictionaries (BGI, GFF3, BL, ...)
 - automatic generation of HTML, diagrams
 - automated generation of json-schema and shex for checking
 - generation of various other downstream artefacts