### PR TITLE
Update gpad-gpi-2-0.md

### DIFF
--- a/specs/gpad-gpi-2-0.md
+++ b/specs/gpad-gpi-2-0.md
@@ -303,7 +303,7 @@ A GP entity is any biological entity that can be annotated using GPAD
 
 Each entity is written on a separate line of tab separated values:
 
-    Entity ::= Col_1 tab Col_2 tab ... Col_9 nl
+    Entity ::= Col_1 tab Col_2 tab ... Col_11 nl
     
     
 ## GPI Columns
@@ -312,14 +312,14 @@ Each entity is written on a separate line of tab separated values:
 --------|----------|-----------|-----------|-----------|-----------|
 1 | DB_Object_ID ::= ID      | | 1 | UniProtKB:Q4VCS5 | |
 2 | DB_Object_Symbol ::= xxxx      | | 1 | AMOT | |
-3 | DB_Object_Name ::= xxxx      | | 0 or greater | Angiomotin | |
-4 | DB_Object_Synonyms ::= [Label] ('\|' Label)*     | | 0 or greater | AMOT\|KIAA1071 | | 
-5 | DB_Object_Type ::= OBO_ID      | Sequence Ontology OR Protein Ontology OR Gene Ontology | 1 or greater | PR:000000001 | | If a gene encodes for both protein and ncRNA, more than one type can be applied.
+3 | DB_Object_Name ::= [Label] ('\|' Label)*  | | 0 or greater | Angiomotin | |
+4 | DB_Object_Synonyms ::= [Label] ('\|' Label)*  | | 0 or greater | AMOT\|KIAA1071 | | 
+5 | DB_Object_Type ::= [OBO_ID] ('\|' OBO_ID)* | Sequence Ontology OR Protein Ontology OR Gene Ontology | 1 or greater | PR:000000001 | | If a gene encodes for both protein and ncRNA, more than one type can be applied.
 6 | DB_Object_Taxon ::= NCBITaxon:[Taxon_ID] || 1 |  NCBITaxon:9606 | | 
 7 | Encoded_By ::= [ID] ('\|' ID)* | | 0 or greater | HGNC:17810  | For proteins and transcripts, this refers to the gene id that encodes those entities. | 
 8 | Parent_Protein ::= [ID] ('\|' ID)* | | 0 or greater |  | When column 1 refers to a protein isoform or modified protein, this column refers to the gene-centric reference protein accession of the column 1 entry. | 
 9 | Protein_Containing_Complex_Members ::= [ID] ('\|' ID)* | | 0 or greater | UniProtKB:Q15021\|UniProtKB:Q15003 | 
-10 | DB_Xrefs ::= [ID] ('\|' ID)* | | 0 or greater | |  See below for required DB xref values |
+10 | DB_Xrefs ::= [ID] ('\|' ID)* | | 0 or greater | HGNC:17810 | See below for required DB xref values |
 11 | Gene_Product_Properties ::= [Property_Value_Pair] ('\|' Property_Value_Pair)* |  | 0 or greater | db-subset=Swiss-Prot  | |
 
     Property_Value_Pair ::= Property_Symbol '=' Property_Value


### PR DESCRIPTION
Updated content field for columns 3 and 5 to indicate how multiple entries should be handled.  Did not update example for these columns, though, as multiple entries don't apply for this specific example and I didn't want to just make something up.  But did add an HGNC xref example based on the current UniProt gpi entry.

Also updated the number of columns in the Entity line grammar.

Thanks @dougli1sqrd for your observant eyes on this!